### PR TITLE
assume no Platform file means PoE is not supported on this platform

### DIFF
--- a/dentos-poe-agent/opt/poeagent/bin/poecli.py
+++ b/dentos-poe-agent/opt/poeagent/bin/poecli.py
@@ -430,6 +430,9 @@ class PoeCLI(object):
 def main(argv):
     try:
         poecli = PoeCLI()
+    except FileNotFoundError as e:
+        print_stderr("This platform does not support PoE.")
+        os._exit(-10)
     except Exception as e:
         print_stderr("Failed to load poe platform! (%s)" % str(e))
         os._exit(-9)

--- a/dentos-poe-agent/opt/poeagent/bin/poed.py
+++ b/dentos-poe-agent/opt/poeagent/bin/poed.py
@@ -183,11 +183,14 @@ class PoeAgent(object):
 
     def load_poe_plat(self):
         poe_plat = None
-        try:
-            plat_src = imp.load_source("poe_plat", self.platform_src_path())
-            poe_plat = plat_src.get_poe_platform()
-        except Exception as e:
-            self.log.alert("Failed to load PoE platform. err: %s" % str(e))
+        if os.path.exists(self.platform_src_path()):
+            try:
+                plat_src = imp.load_source("poe_plat", self.platform_src_path())
+                poe_plat = plat_src.get_poe_platform()
+            except Exception as e:
+                self.log.alert("Failed to load PoE platform. err: %s" % str(e))
+        else:
+            self.log.info("No PoE platform found, assuming no PoE support.")
         return poe_plat
 
     def is_valid_plat(self, poe_plat):


### PR DESCRIPTION
Currently, both `poed` and `poecli` treat the absence of a platform file as an error. But non-PoE platforms do not have one, so this case is actually expected.

So change `poed` and `poecli`  to treat this is meaning that there is no PoE support, and print a less alarming message, as well reduce its level to INFO for `poed`.