### PR TITLE
drop deprecated imp module use

### DIFF
--- a/dentos-poe-agent/opt/poeagent/bin/poecli.py
+++ b/dentos-poe-agent/opt/poeagent/bin/poecli.py
@@ -21,7 +21,6 @@ from poe_version import *
 
 import binascii
 import re
-import imp
 import sys
 import subprocess
 import os
@@ -64,7 +63,7 @@ class PoeCLI(object):
             print_stderr("Failed to get platform path. err: %s" % str(e))
 
     def load_poe_platform(self):
-        plat_src = imp.load_source("poe_plat", self.platform_src_path())
+        plat_src = load_source("poe_plat", self.platform_src_path())
         poe_plat = plat_src.get_poe_platform()
         return poe_plat
 

--- a/dentos-poe-agent/opt/poeagent/bin/poed.py
+++ b/dentos-poe-agent/opt/poeagent/bin/poed.py
@@ -25,7 +25,6 @@ import sys
 import errno
 import threading
 import signal
-import imp
 import time
 import json
 import fcntl
@@ -184,7 +183,7 @@ class PoeAgent(object):
     def load_poe_plat(self):
         poe_plat = None
         try:
-            plat_src = imp.load_source("poe_plat", self.platform_src_path())
+            plat_src = load_source("poe_plat", self.platform_src_path())
             poe_plat = plat_src.get_poe_platform()
         except Exception as e:
             self.log.alert("Failed to load PoE platform. err: %s" % str(e))

--- a/dentos-poe-agent/opt/poeagent/inc/poe_common.py
+++ b/dentos-poe-agent/opt/poeagent/inc/poe_common.py
@@ -20,6 +20,7 @@ import time
 import syslog
 import fcntl
 import traceback
+import importlib.util
 from pathlib import Path
 
 # POE Driver Attributes
@@ -297,3 +298,13 @@ def check_init_plat_ret_result(init_poe_result, sum_mode=0):
         elif type(itm_result) is int:
             sum_result += itm_result
     return (all_ret, sum_result)
+
+def load_source(name, pathname):
+    module = None
+    spec = None
+
+    spec = importlib.util.spec_from_file_location(name, pathname)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module


### PR DESCRIPTION
Replace the deprecated `imp.load_source()` with a helper function imitating it to fix the warning on startup.

The replacement works with Python 3.5+, which should be fine, since this is the version in Debian 9, while Debian 10 even has Python 3.7.

Note that this is not fully run-tested, since I do not have access to a PoE capable machine, but at least loading a dummy `poe_platform.py` that prints something in its `get_poe_platform()` did produce the expected output.